### PR TITLE
twistedActor seems to prefer rn lineTerminator, without b specification

### DIFF
--- a/python/opscore/RO/Comm/TwistedSocket.py
+++ b/python/opscore/RO/Comm/TwistedSocket.py
@@ -150,7 +150,7 @@ class Socket(BaseSocket):
         stateCallback = nullCallback,
         timeLim = None,
         name = "",
-        lineTerminator = b"\r\n",
+        lineTerminator = "\r\n",
     ):
         """Construct a Socket
 
@@ -350,7 +350,7 @@ class TCPSocket(Socket):
         stateCallback = None,
         timeLim = None,
         name = "",
-        lineTerminator = b"\r\n",
+        lineTerminator = "\r\n",
     ):
         """Construct a TCPSocket
 


### PR DESCRIPTION
I had to change b"\r\n" to just "\r\n" to get alertsActor to work with this RO. Everything else seemed the same as the RO branch I modified a few months ago.

The various string formats in Python are exhausting, so pull request as a sanity check. If this sounds good we should cut a bug fix version and push to pypi.